### PR TITLE
Do not get properties from cache WE-274

### DIFF
--- a/src/SoundInTheory.DynamicImage/Caching/ImageUrlGenerator.cs
+++ b/src/SoundInTheory.DynamicImage/Caching/ImageUrlGenerator.cs
@@ -10,7 +10,7 @@ namespace SoundInTheory.DynamicImage.Caching
 			string cacheKey = composition.GetCacheKey();
 
 			if (DynamicImageCacheManager.Exists(cacheKey))
-				return GetUrl(cacheKey, DynamicImageCacheManager.GetProperties(cacheKey));
+				return GetUrl(cacheKey, composition.ImageFormat);
 
 			GeneratedImage generatedImage = composition.GenerateImage();
 			if (generatedImage.Properties.IsImagePresent || DynamicImageCacheManager.StoreMissingImagesInCache)
@@ -18,13 +18,13 @@ namespace SoundInTheory.DynamicImage.Caching
 				Dependency[] dependencies = composition.GetDependencies().Distinct().ToArray();
 				DynamicImageCacheManager.Add(cacheKey, generatedImage, dependencies);
 			}
-			return GetUrl(cacheKey, generatedImage.Properties);
+			return GetUrl(cacheKey, generatedImage.Properties.Format);
 		}
 
-		private static string GetUrl(string cacheKey, ImageProperties imageProperties)
+		private static string GetUrl(string cacheKey, DynamicImageFormat imageFormat)
 		{
 			const string path = "~/Assets/Images/DynamicImages/";
-			string fileName = string.Format("{0}.{1}", cacheKey, imageProperties.FileExtension);
+			string fileName = string.Format("{0}.{1}", cacheKey, ImageProperties.FormatToFileExtension(imageFormat));
 			return VirtualPathUtility.ToAbsolute(path) + fileName;
 		}
 	}

--- a/src/SoundInTheory.DynamicImage/ImageProperties.cs
+++ b/src/SoundInTheory.DynamicImage/ImageProperties.cs
@@ -31,27 +31,26 @@ namespace SoundInTheory.DynamicImage
 
 			return encoder;
 		}
+		
+		public string FileExtension => FormatToFileExtension(Format);
 
 		/// <summary>
 		/// Gets the file extension, not including a '.'
 		/// </summary>
-		public string FileExtension
+		public static string FormatToFileExtension(DynamicImageFormat format)
 		{
-			get
+			switch (format)
 			{
-				switch (Format)
-				{
-					case DynamicImageFormat.Bmp:
-						return "bmp";
-					case DynamicImageFormat.Gif:
-						return "gif";
-					case DynamicImageFormat.Jpeg:
-						return "jpg";
-					case DynamicImageFormat.Png:
-						return "png";
-					default:
-						throw new InvalidOperationException("Unrecognised DynamicImageFormat");
-				}
+				case DynamicImageFormat.Bmp:
+					return "bmp";
+				case DynamicImageFormat.Gif:
+					return "gif";
+				case DynamicImageFormat.Jpeg:
+					return "jpg";
+				case DynamicImageFormat.Png:
+					return "png";
+				default:
+					throw new InvalidOperationException("Unrecognised DynamicImageFormat");
 			}
 		}
 


### PR DESCRIPTION
The information required to construct the uri is already available to us so don't hit the in-memory x-document to get this info.

This does raise a separate issue. If the XDocument object should have protected access then the DynamicImageCacheManager.Exists() method is currently not thread safe. However, adding a lock to this will just move the bottleneck that we're currently experiencing on our services.

We should look optimising our cache performance further.